### PR TITLE
fixed the validation - changed the edit-UI slightly

### DIFF
--- a/src/cashbook/cashbook.wpf/EnumToBoolConverter.cs
+++ b/src/cashbook/cashbook.wpf/EnumToBoolConverter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace cashbook.wpf
+{
+    public class EnumToBoolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string param = parameter as string;
+            if (param == null)
+                return DependencyProperty.UnsetValue;
+            if (Enum.IsDefined(value.GetType(), value) == false)
+                return DependencyProperty.UnsetValue;
+
+
+            object paramValue = Enum.Parse(value.GetType(), param);
+            return paramValue.Equals(value);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string param = parameter as string;
+            if (parameter == null)
+                return DependencyProperty.UnsetValue;
+
+
+            return Enum.Parse(targetType, param);
+        }
+    }
+}

--- a/src/cashbook/cashbook.wpf/MainViewModel.cs
+++ b/src/cashbook/cashbook.wpf/MainViewModel.cs
@@ -207,31 +207,31 @@ namespace cashbook.wpf
             {
                 case TransactionType.Withdraw:
                     _body.Withdraw(EditDate, EditAmount, EditDescription, EditForce,
-                        _ =>
-                        {
-                            ClearEdit();
-                            ShowSelectedMonth();
-                        },
-                        errormsg =>
-                        {
-                            MessageBox.Show(errormsg, "could not withdraw", MessageBoxButton.OK, MessageBoxImage.Error);
-                        });
+                        UpdateUI, ShowErrorMessage("could not withdraw"));
                     break;
                 case TransactionType.Deposit:
                     _body.Deposit(EditDate, EditAmount, EditDescription, EditForce,
-                        _ =>
-                        {
-                            ClearEdit();
-                            ShowSelectedMonth();
-                        },
-                        errormsg =>
-                        {
-                            MessageBox.Show(errormsg, "could not deposit", MessageBoxButton.OK, MessageBoxImage.Error);
-                        });
+                        UpdateUI, ShowErrorMessage("could not deposit"));
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+        }
+
+        private void UpdateUI()
+        {
+            ClearEdit();
+            ShowSelectedMonth();
+        }
+
+        private void UpdateUI(Balance ignore)
+        {
+            UpdateUI();
+        }
+
+        private Action<string> ShowErrorMessage(string caption)
+        {
+            return errormsg => MessageBox.Show(errormsg, caption, MessageBoxButton.OK, MessageBoxImage.Error);
         }
 
         private void ClearEdit()

--- a/src/cashbook/cashbook.wpf/MainWindow.xaml
+++ b/src/cashbook/cashbook.wpf/MainWindow.xaml
@@ -8,11 +8,12 @@
         <wpf:MainViewModel />
     </Window.DataContext>
     <Window.Resources>
+        <wpf:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
         <ControlTemplate x:Key="validationTemplate">
-            <Grid ToolTip="{Binding Path=/ErrorContent}">
+            <Grid ToolTip="{Binding /ErrorContent}">
                 <Ellipse Fill="Red" Opacity="0.5" Width="10" Height="10"
                  HorizontalAlignment="Right" VerticalAlignment="Top"
-                 ToolTip="{Binding Path=/ErrorContent}" Margin="0,-3,-7,0" />
+                 ToolTip="{Binding /ErrorContent}" Margin="0,-3,-7,0" />
                 <AdornedElementPlaceholder />
             </Grid>
         </ControlTemplate>
@@ -77,27 +78,24 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <DatePicker x:Name="EditDate" Grid.Column="0" Margin="5" VerticalAlignment="Center" SelectedDate="{Binding EditDate}" Validation.ErrorTemplate="{StaticResource validationTemplate}"></DatePicker>
-            <TextBox Grid.Column="1" Margin="5" MinWidth="200" VerticalAlignment="Center" Text="{Binding EditDescription}" GotFocus="UIElement_OnGotFocus" Validation.ErrorTemplate="{StaticResource validationTemplate}"></TextBox>
-            <TextBox Grid.Column="2" Margin="5" MinWidth="50" TextAlignment="Right" VerticalAlignment="Center" Text="{Binding EditAmount, StringFormat={}{0:0.00€}}" GotFocus="UIElement_OnGotFocus" Validation.ErrorTemplate="{StaticResource validationTemplate}"/>
-            <CheckBox Grid.Column="3" Margin="5" VerticalAlignment="Center" IsChecked="{Binding EditForce}">force?</CheckBox>
-            <StackPanel Grid.Column="4" Margin="5" HorizontalAlignment="Left">
-                <Button Command="{Binding WithdrawCommand, Mode=OneWay}">
-                    <i:Interaction.Behaviors>
-                        <wpf:SetFocusAfterClickBehavior FocusElement="{Binding ElementName=EditDate, Mode=OneWay}"/>
-                    </i:Interaction.Behaviors> 
-                    Withdraw
-                </Button>
-                <Button Command="{Binding DepositCommand, Mode=OneWay}">
-                    <i:Interaction.Behaviors>
-                        <wpf:SetFocusAfterClickBehavior FocusElement="{Binding ElementName=EditDate, Mode=OneWay}"/>
-                    </i:Interaction.Behaviors>
-                    Deposit
-                </Button>
+            <StackPanel Grid.Column="0" Margin="5">
+                <RadioButton IsChecked="{Binding EditTransactionType, ConverterParameter=Withdraw, Converter={StaticResource EnumToBoolConverter}}">withdraw</RadioButton>
+                <RadioButton IsChecked="{Binding EditTransactionType, ConverterParameter=Deposit, Converter={StaticResource EnumToBoolConverter}}">deposit</RadioButton>
             </StackPanel>
+            <DatePicker Grid.Column="1" x:Name="EditDate" Margin="5" VerticalAlignment="Center" SelectedDate="{Binding EditDate}" Validation.ErrorTemplate="{StaticResource validationTemplate}"></DatePicker>
+            <TextBox Grid.Column="2" Margin="5" MinWidth="200" VerticalAlignment="Center" Text="{Binding EditDescription}" GotFocus="UIElement_OnGotFocus" Validation.ErrorTemplate="{StaticResource validationTemplate}"></TextBox>
+            <TextBox Grid.Column="3" Margin="5" MinWidth="50" TextAlignment="Right" VerticalAlignment="Center" Text="{Binding EditAmount, StringFormat={}{0:0.00€}}" GotFocus="UIElement_OnGotFocus" Validation.ErrorTemplate="{StaticResource validationTemplate}"/>
+            <CheckBox Grid.Column="4" Margin="5" VerticalAlignment="Center" IsChecked="{Binding EditForce}">force?</CheckBox>
+            <Button Grid.Column="5" Command="{Binding TransactionCommand, Mode=OneWay}" Margin="5" VerticalAlignment="Center" HorizontalAlignment="Left">
+                <i:Interaction.Behaviors>
+                    <wpf:SetFocusAfterClickBehavior FocusElement="{Binding ElementName=EditDate, Mode=OneWay}"/>
+                </i:Interaction.Behaviors> 
+                Process
+            </Button>
         </Grid>
 
     </Grid>

--- a/src/cashbook/cashbook.wpf/SetFocusAfterClickBehavior.cs
+++ b/src/cashbook/cashbook.wpf/SetFocusAfterClickBehavior.cs
@@ -30,6 +30,19 @@ namespace cashbook.wpf
         void AssociatedButtonClick(object sender, RoutedEventArgs e)
         {
             Keyboard.Focus(FocusElement);
+
+            if (FocusElement is DatePicker)
+            {
+                // HACK: get the date-picker to focus the textbox-part by sending a Key.Up
+                var eventArgs = new KeyEventArgs(
+                    Keyboard.PrimaryDevice,
+                    Keyboard.PrimaryDevice.ActiveSource,
+                    0,
+                    Key.Up) 
+                    {RoutedEvent = UIElement.KeyDownEvent};
+
+                FocusElement.RaiseEvent(eventArgs);                
+            }
         }
 
         public Control FocusElement

--- a/src/cashbook/cashbook.wpf/cashbook.wpf.csproj
+++ b/src/cashbook/cashbook.wpf/cashbook.wpf.csproj
@@ -66,6 +66,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="DelegateCommand.cs" />
+    <Compile Include="EnumToBoolConverter.cs" />
     <Compile Include="SetFocusAfterClickBehavior.cs" />
     <Compile Include="MainViewModel.cs" />
     <Compile Include="MainWindow.xaml.cs">
@@ -112,6 +113,9 @@
       <Project>{d696ffe8-f073-4a62-905d-728f4f1749db}</Project>
       <Name>cashbook.contracts</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
I changed the issue with the different validations for deposit and withdraw.

Instead of disabling the two buttons I choose to add a radio-button group for the desired action.
I know that's not what the initial design was supposed to be, but it's far more elegant IMO as you can now see exactly what went wrong (for example that you need a description for the withdraw) instead of just having the button grayed out.

On top of this the implementation is far more streamlined this way (have a look).
